### PR TITLE
Integrate ViT features into CBENet and BGShadowNet

### DIFF
--- a/Train_BGShadowNet.py
+++ b/Train_BGShadowNet.py
@@ -18,9 +18,8 @@ from albumentations import (
     Normalize,
 )
 from albumentations.pytorch import ToTensorV2
-from libs.models.CBENet import *
-from libs.models.stageI import *
-from libs.models.stageII import *
+from libs.models.vit_cbenet import ViTCBENet
+from libs.models.vit_bgshadownet import ViTBGShadowNet1, ViTBGShadowNet2
 from libs.models.models import Discriminator
 from libs.checkpoint import save_checkpoint_BGShadowNet
 from libs.config import get_config
@@ -146,16 +145,16 @@ def main() -> None:
     n_classes = 1
 
     # define a model
-    cbeNet = CBENet(3)  # 背景估计网络
-    cbeNet_weights = torch.load('./pretrained/pretrained_CBENet.prm')
+    cbeNet = ViTCBENet(pretrained_vit=config.vit_pretrained)  # 背景估计网络
+    cbeNet_weights = torch.load('./pretrained/pretrained_ViTCBENet.prm')
     cbeNet.load_state_dict(fix_model_state_dict(cbeNet_weights))
-    firstStage_BGShadowNet = BGShadowNet1(3)  # 第一阶段网络
-    secondStage_BGShadowNet = BGShadowNet2(6)  # 第二阶段网络
+    firstStage_BGShadowNet = ViTBGShadowNet1(pretrained_vit=config.vit_pretrained)  # 第一阶段网络
+    secondStage_BGShadowNet = ViTBGShadowNet2(pretrained_vit=config.vit_pretrained)  # 第二阶段网络
     discriminator = Discriminator(6)
     if config.pretrained == True:
-        firstStage_BGShadowNet_weights = torch.load('./pretrained/pretrained_firstStage_for_BGShadowNet.prm')
+        firstStage_BGShadowNet_weights = torch.load('./pretrained/pretrained_firstStage_ViT_for_BGShadowNet.prm')
         firstStage_BGShadowNet.load_state_dict(fix_model_state_dict(firstStage_BGShadowNet_weights))
-        refine_weights = torch.load('./pretrained/pretrained_secondStage_for_BGShadowNet.prm')
+        refine_weights = torch.load('./pretrained/pretrained_secondStage_ViT_for_BGShadowNet.prm')
         secondStage_BGShadowNet.load_state_dict(fix_model_state_dict(refine_weights))
         discriminator_weights = torch.load('./pretrained/pretrained_discriminator_for_BGShadowNet.prm')
         discriminator.load_state_dict(fix_model_state_dict(discriminator_weights))
@@ -224,10 +223,10 @@ def main() -> None:
             torch.save(discriminator.state_dict(),
                        os.path.join(result_path, "pretrained_discriminator_for_BGShadowNet" + str(epoch) + ".prm"), )
             torch.save(firstStage_BGShadowNet.state_dict(),
-                       os.path.join(result_path, "pretrained_firstStage_for_BGShadowNet" + str(epoch) + ".prm"), )
+                       os.path.join(result_path, "pretrained_firstStage_ViT_for_BGShadowNet" + str(epoch) + ".prm"), )
             torch.save(
                 secondStage_BGShadowNet.state_dict(),
-                os.path.join(result_path, "pretrained_secondStage_for_BGShadowNet" + str(epoch) + ".prm"),
+                os.path.join(result_path, "pretrained_secondStage_ViT_for_BGShadowNet" + str(epoch) + ".prm"),
             )
         # save a model if top1 acc is higher than ever
         if best_g_loss > train_g_loss:
@@ -235,11 +234,11 @@ def main() -> None:
             best_d_loss = train_d_loss
             torch.save(
                 firstStage_BGShadowNet.state_dict(),
-                os.path.join(result_path, "pretrained_firstStage_for_BGShadowNet.prm"),
+                os.path.join(result_path, "pretrained_firstStage_ViT_for_BGShadowNet.prm"),
             )
             torch.save(
                 secondStage_BGShadowNet.state_dict(),
-                os.path.join(result_path, "pretrained_secondStage_for_BGShadowNet.prm"),
+                os.path.join(result_path, "pretrained_secondStage_ViT_for_BGShadowNet.prm"),
             )
             torch.save(
                 discriminator.state_dict(),

--- a/Train_CBENet.py
+++ b/Train_CBENet.py
@@ -3,10 +3,11 @@ import datetime
 import os
 import time
 from logging import DEBUG, INFO, basicConfig, getLogger
-from libs.models.CBENet import *
 import torch
 import torch.optim as optim
 import wandb
+
+from libs.models.vit_cbenet import ViTCBENet
 from albumentations import (
     Compose,
     RandomResizedCrop,
@@ -104,7 +105,7 @@ def main() -> None:
         drop_last=True,
         transform=train_transform,
     )
-    model = CBENet(3)
+    model = ViTCBENet(pretrained_vit=config.vit_pretrained)
     # send the model to cuda/cpu
     model.to(device)
     optimizer = optim.Adam(model.parameters(), lr=config.learning_rate)
@@ -157,7 +158,7 @@ def main() -> None:
             best_loss = train_loss
             torch.save(
                 model.state_dict(),
-                os.path.join(result_path, "pretrained_CBENet.prm"),
+                os.path.join(result_path, "pretrained_ViTCBENet.prm"),
             )
 
         # save checkpoint every epoch

--- a/configs/model=BGShadowNet/config.yaml
+++ b/configs/model=BGShadowNet/config.yaml
@@ -1,14 +1,18 @@
 batch_size: 8
 beta1: 0.9
 beta2: 0.999
-dataset_name: RDD
+dataset_name:
+  - RDD
+  - Jung
+  - Kliger
 height: 256
 lambda1: 1.0
 lambda2: 0.01
-learning_rate: 0.0002
+learning_rate: 0.00039
 loss_function_name: GAN
 max_epoch: 400
-model: BGShadowNet
+model: ViTBGShadowNet
+vit_pretrained: True
 num_workers: 4
 pretrained: True
 width: 256

--- a/configs/model=CBENet/config.yaml
+++ b/configs/model=CBENet/config.yaml
@@ -5,10 +5,11 @@ dataset_name: RDD
 height: 256
 lambda1: 1.0
 lambda2: 0.01
-learning_rate: 0.0002
+learning_rate: 0.00039
 loss_function_name: L1
 max_epoch: 400
-model: CBENet
+model: ViTCBENet
+vit_pretrained: True
 num_workers: 4
 pretrained: True
 width: 256

--- a/libs/config.py
+++ b/libs/config.py
@@ -18,6 +18,7 @@ class Config:
 
     model: str = "BGShadowNet"
     pretrained: bool = True
+    vit_pretrained: bool = True
 
     batch_size: int = 32
 
@@ -29,7 +30,7 @@ class Config:
 
     learning_rate: float = 0.003
 
-    dataset_name: str = "Jung"
+    dataset_name: Tuple[str, ...] = ("Jung",)
 
     loss_function_name: str = "L1"
 
@@ -48,12 +49,13 @@ class Config:
         )
 
     def _value_check(self) -> None:
-        if self.dataset_name not in DATASET_CSVS:
-            message = (
-                f"dataset_name should be selected from {list(DATASET_CSVS.keys())}."
-            )
-            logger.error(message)
-            raise ValueError(message)
+        for name in self.dataset_name:
+            if name not in DATASET_CSVS:
+                message = (
+                    f"dataset_name should be selected from {list(DATASET_CSVS.keys())}."
+                )
+                logger.error(message)
+                raise ValueError(message)
 
         if self.max_epoch <= 0:
             message = "max_epoch must be positive."
@@ -108,6 +110,9 @@ def convert_list2tuple(_dict: Dict[str, Any]) -> Dict[str, Any]:
     for key, val in _dict.items():
         if isinstance(val, list):
             _dict[key] = tuple(val)
+
+    if "dataset_name" in _dict and isinstance(_dict["dataset_name"], str):
+        _dict["dataset_name"] = (_dict["dataset_name"],)
 
     logger.debug("converted list to tuple in dictionary.")
     return _dict

--- a/libs/dataset_csv.py
+++ b/libs/dataset_csv.py
@@ -25,4 +25,9 @@ DATASET_CSVS = {
         val="./csv/RDD/val.csv",
         test="./csv/RDD/test.csv",
     ),
+    "Kliger": DatasetCSV(
+        train="./csv/Kliger/train.csv",
+        val="./csv/Kliger/val.csv",
+        test="./csv/Kliger/test.csv",
+    ),
 }

--- a/libs/models/vit_backbone.py
+++ b/libs/models/vit_backbone.py
@@ -1,0 +1,72 @@
+"""Vision Transformer backbone for DISR_ViTs.
+
+This module provides a simple wrapper around a ViT model from
+``torchvision`` that exposes a CNN‑like feature map. The resulting tensor
+can be integrated with the existing CBENet/BGShadowNet pipelines.
+
+The implementation assumes that ``torchvision`` provides the
+``vit_b_16`` model. If the current version of ``torchvision`` does not
+include ViT models, importing :class:`ViTBackbone` will raise an
+``ImportError`` at runtime.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import torch.nn as nn
+
+try:  # ``vit_b_16`` is available in torchvision >= 0.13
+    from torchvision.models import vit_b_16, ViT_B_16_Weights
+except Exception:  # pragma: no cover - handled at runtime
+    vit_b_16 = None  # type: ignore
+    ViT_B_16_Weights = None  # type: ignore
+
+
+class ViTBackbone(nn.Module):
+    """Backbone that extracts 2D feature maps using a Vision Transformer.
+
+    Parameters
+    ----------
+    pretrained: bool
+        If ``True`` (default), loads ImageNet pretrained weights when
+        available. Otherwise the model is randomly initialized.
+    """
+
+    def __init__(self, pretrained: bool = True) -> None:
+        super().__init__()
+        if vit_b_16 is None:
+            raise ImportError(
+                "torchvision>=0.13 with ViT support is required for ViTBackbone"
+            )
+
+        weights: Optional[ViT_B_16_Weights]
+        if pretrained and ViT_B_16_Weights is not None:  # type: ignore[assignment]
+            weights = ViT_B_16_Weights.DEFAULT
+        else:
+            weights = None
+
+        self.vit = vit_b_16(weights=weights)  # type: ignore[call-arg]
+        # Remove classification head to expose raw features
+        self.vit.heads = nn.Identity()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Compute feature maps from an input tensor.
+
+        The output tensor has shape ``(B, C, H, W)`` where ``H`` and ``W``
+        correspond to the number of patches along each spatial dimension.
+        """
+
+        # ``_process_input`` converts the image to a patch sequence
+        x = self.vit._process_input(x)
+        # Encoder returns sequence with class token at index 0
+        x = self.vit.encoder(x)
+        x = x[:, 1:, :]  # remove class token
+
+        n_patches = x.shape[1]
+        h = w = int(n_patches ** 0.5)
+        x = x.reshape(x.shape[0], h, w, x.shape[2]).permute(0, 3, 1, 2).contiguous()
+        return x
+
+__all__ = ["ViTBackbone"]

--- a/libs/models/vit_bgshadownet.py
+++ b/libs/models/vit_bgshadownet.py
@@ -1,0 +1,100 @@
+"""BGShadowNet variants with integrated ViT features."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from .vit_backbone import ViTBackbone
+from .stageI import FCDenseNet as StageIFCDenseNet
+from .stageII import FCDenseNet as StageIIFCDenseNet
+
+
+class ViTBGShadowNet1(StageIFCDenseNet):
+    """First stage of BGShadowNet enhanced with ViT features."""
+
+    def __init__(self, pretrained_vit: bool = True) -> None:
+        super().__init__(
+            in_channels=6,
+            down_blocks=(4, 4, 4, 4, 4),
+            up_blocks=(4, 4, 4, 4, 4),
+            bottleneck_layers=16,
+            growth_rate=12,
+            out_chans_first_conv=48,
+        )
+        self.vit = ViTBackbone(pretrained=pretrained_vit)
+        self.proj = nn.Conv2d(768, 3, kernel_size=1)
+
+    def forward(self, x: torch.Tensor, featureMaps):
+        vit_feat = self.vit(x)
+        vit_feat = F.interpolate(
+            vit_feat, size=x.shape[-2:], mode="bilinear", align_corners=False
+        )
+        vit_feat = self.proj(vit_feat)
+        x = torch.cat([x, vit_feat], dim=1)
+        return super().forward(x, featureMaps)
+
+
+class ViTBGShadowNet2(StageIIFCDenseNet):
+    """Second stage of BGShadowNet enhanced with ViT features."""
+
+    def __init__(self, pretrained_vit: bool = True) -> None:
+        super().__init__(
+            in_channels=9,
+            down_blocks=(4, 4, 4, 4, 4),
+            up_blocks=(4, 4, 4, 4, 4),
+            bottleneck_layers=12,
+            growth_rate=12,
+            out_chans_first_conv=48,
+        )
+        self.vit = ViTBackbone(pretrained=pretrained_vit)
+        self.proj = nn.Conv2d(768, 3, kernel_size=1)
+
+    def forward(self, confuse_result, background, shadow_img, featureMaps):
+        vit_feat = self.vit(shadow_img)
+        vit_feat = F.interpolate(
+            vit_feat, size=shadow_img.shape[-2:], mode="bilinear", align_corners=False
+        )
+        vit_feat = self.proj(vit_feat)
+        x = torch.cat([confuse_result, shadow_img, vit_feat], dim=1)
+
+        background_feature = []
+        back1 = self.Cv0(background)
+        background_feature.append(back1)
+        back2 = self.Cv1(back1)
+        background_feature.append(back2)
+        back3 = self.Cv2(back2)
+        background_feature.append(back3)
+        back4 = self.Cv3(back3)
+        background_feature.append(back4)
+        back5 = self.Cv4(back4)
+        background_feature.append(back5)
+
+        out = self.firstconv(x)
+        DEModuleFirst = self.DEModulefirstConv(x)
+        skip_connections = []
+        newFeatureMap = []
+        for i in range(len(self.down_blocks)):
+            out = self.denseBlocksDown[i](out)
+            background_featuremap = background_feature[i]
+            skip = torch.cat((out, background_featuremap), 1)
+            att = getattr(self, f"att{i}")(skip)
+            skip = skip * att
+            skip_connections.append(skip)
+            newFeatureMap.append(out)
+            out = self.transDownBlocks[i](out)
+        DEModuleinput = torch.cat([DEModuleFirst, skip_connections[1]], dim=1)
+        DEModuleresult = self.DEModule(DEModuleinput)
+        skip_connections[1] = torch.cat([skip_connections[1], DEModuleresult], dim=1)
+        out = self.bottleneck(out)
+        for i in range(len(self.up_blocks)):
+            skip = skip_connections.pop()
+            featureMap = featureMaps.pop()
+            out = self.transUpBlocks[i](out, skip, featureMap)
+            out = self.denseBlocksUp[i](out)
+        out = self.finalConv(out)
+        return out, newFeatureMap
+
+
+__all__ = ["ViTBGShadowNet1", "ViTBGShadowNet2"]

--- a/libs/models/vit_cbenet.py
+++ b/libs/models/vit_cbenet.py
@@ -1,0 +1,56 @@
+"""CBENet with ViT backbone features.
+
+This module extends the original CBENet by extracting global
+representations with a Vision Transformer and fusing them with the
+convolutional input. The ViT features are projected to three channels
+and concatenated with the RGB input before being processed by the
+FCDenseNet architecture.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from .vit_backbone import ViTBackbone
+from .CBENet import FCDenseNet
+
+
+class ViTCBENet(nn.Module):
+    """CBENet variant that incorporates ViT features."""
+
+    def __init__(self, pretrained_vit: bool = True) -> None:
+        super().__init__()
+        # Vision Transformer backbone
+        self.vit = ViTBackbone(pretrained=pretrained_vit)
+        # Project high-dimensional ViT features to 3 channels
+        self.proj = nn.Conv2d(768, 3, kernel_size=1)
+        # Original CBENet expecting six-channel input (RGB + ViT features)
+        self.cbenet = FCDenseNet(
+            in_channels=6,
+            down_blocks=(4, 4, 4, 4, 4),
+            up_blocks=(4, 4, 4, 4, 4),
+            bottleneck_layers=16,
+            growth_rate=12,
+            out_chans_first_conv=48,
+        )
+
+    def forward(self, x: torch.Tensor):
+        """Forward pass.
+
+        Parameters
+        ----------
+        x: torch.Tensor
+            Input RGB image of shape ``(B, 3, H, W)``.
+        """
+        vit_feat = self.vit(x)
+        vit_feat = F.interpolate(
+            vit_feat, size=x.shape[-2:], mode="bilinear", align_corners=False
+        )
+        vit_feat = self.proj(vit_feat)
+        fused = torch.cat([x, vit_feat], dim=1)
+        return self.cbenet(fused)
+
+
+__all__ = ["ViTCBENet"]

--- a/test.py
+++ b/test.py
@@ -3,22 +3,22 @@
 import cv2
 import numpy as np
 import os
+import torch
 from libs.models.models import Discriminator
 os.environ["CUDA_VISIBLE_DEVICES"] = "0"
 from libs.fix_weight_dict import fix_model_state_dict
-from libs.models.CBENet import *
-from libs.models.stageI import *
 from albumentations import (
     Compose,
     Normalize,
     Resize
 )
-from libs.models.stageII import *
 from albumentations.pytorch import ToTensorV2
 from utils.visualize import visualize, reverse_normalize
 from libs.dataset import get_dataloader
 from libs.loss_fn import get_criterion
 from libs.helper_BGShadowNet import do_one_iteration
+from libs.models.vit_cbenet import ViTCBENet
+from libs.models.vit_bgshadownet import ViTBGShadowNet1, ViTBGShadowNet2
 if __name__ == '__main__':
 
     def convert_show_image(tensor, idx=None):
@@ -37,7 +37,7 @@ if __name__ == '__main__':
     test_transform = Compose([Resize(256,256), Normalize(mean=(0.5,), std=(0.5,)), ToTensorV2()])
     test_loader = get_dataloader(
             "RDD",
-            "BGShadowNet",
+            "ViTBGShadowNet",
             "test",
             batch_size=1,
             shuffle=False,
@@ -46,20 +46,20 @@ if __name__ == '__main__':
             transform=test_transform,
         )
     device = "cuda" if torch.cuda.is_available() else "cpu"
-    cbeNet = CBENet(3)
-    firstStage_BGShadowNet = BGShadowNet1(3)
+    cbeNet = ViTCBENet()
+    firstStage_BGShadowNet = ViTBGShadowNet1()
     discriminator = Discriminator(6)
-    cbeNet_weights = torch.load('./pretrained/pretrained_CBENet.prm')
+    cbeNet_weights = torch.load('./pretrained/pretrained_ViTCBENet.prm')
     cbeNet.load_state_dict(fix_model_state_dict(cbeNet_weights))
 
-    firstStage_BGShadowNet_weights = torch.load('./pretrained/pretrained_firstStage_for_BGShadowNet.prm')
+    firstStage_BGShadowNet_weights = torch.load('./pretrained/pretrained_firstStage_ViT_for_BGShadowNet.prm')
     firstStage_BGShadowNet.load_state_dict(fix_model_state_dict(firstStage_BGShadowNet_weights))
 
     discriminator_weights = torch.load('./pretrained/pretrained_discriminator_for_BGShadowNet.prm')
     discriminator.load_state_dict(fix_model_state_dict(discriminator_weights))
 
-    secondStage_BGShadowNet =BGShadowNet2(6)
-    refine_weights = torch.load('./pretrained/pretrained_secondStage_for_BGShadowNet.prm')
+    secondStage_BGShadowNet = ViTBGShadowNet2()
+    refine_weights = torch.load('./pretrained/pretrained_secondStage_ViT_for_BGShadowNet.prm')
     secondStage_BGShadowNet.load_state_dict(fix_model_state_dict(refine_weights))
     firstStage_BGShadowNet.eval()
     discriminator.eval()


### PR DESCRIPTION
## Summary
- add ViT-augmented CBENet and BGShadowNet modules
- expose `vit_pretrained` option and updated configs, dataset loader, and training scripts to support ViT models
- allow BGShadowNet configuration to use multiple datasets (RDD, Jung, Kliger)
- tune training configuration to use learning rate 0.00039

## Testing
- `python -m py_compile libs/config.py libs/dataset.py libs/dataset_csv.py Train_CBENet.py Train_BGShadowNet.py test.py libs/models/vit_backbone.py libs/models/vit_cbenet.py libs/models/vit_bgshadownet.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement albumentations==1.1.0; proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bed62dfa4c83299a2f94a5eef2ee75